### PR TITLE
NavBar & Leaderboards

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -20,9 +20,7 @@ urlpatterns = [
     path("users/", include("trivianator.users.urls", namespace="users")),
     path("accounts/", include("allauth.urls")),
     # Your stuff: custom urls includes go here
-    path("progress/",view=tviews.QuizUserProgressView.as_view(), name="progress"),
-    path("leaderboards/",view=tviews.QuizLeaderboardsView.as_view(), name="leaderboards"),
-    re_path('^trivia/', include('trivianator.trivia.urls')),
+    re_path('^', include('trivianator.trivia.urls')),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 
 

--- a/config/urls.py
+++ b/config/urls.py
@@ -20,6 +20,8 @@ urlpatterns = [
     path("users/", include("trivianator.users.urls", namespace="users")),
     path("accounts/", include("allauth.urls")),
     # Your stuff: custom urls includes go here
+    path("progress/",view=tviews.QuizUserProgressView.as_view(), name="progress"),
+    path("leaderboards/",view=tviews.QuizLeaderboardsView.as_view(), name="leaderboards"),
     re_path('^trivia/', include('trivianator.trivia.urls')),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 

--- a/trivianator/templates/base.html
+++ b/trivianator/templates/base.html
@@ -52,12 +52,10 @@
             </li>
             {% if request.user.is_authenticated %}
               <li class="nav-item">
-                {# URL provided by django-allauth/account/urls.py #}
-                <a class="nav-link" href="{% url 'trivia/progress' request.user.username  %}">{% trans "Progress" %}</a>
+                <a class="nav-link" href="{% url 'progress' %}">{% trans "Progress" %}</a>
               </li>
               <li class="nav-item">
-                {# URL provided by django-allauth/account/urls.py #}
-                <a class="nav-link" href="{% url 'trivia/leaderboards' request.user.username  %}">{% trans "Leaderboards" %}</a>
+                <a class="nav-link" href="{% url 'leaderboards' %}">{% trans "Leaderboards" %}</a>
               </li>
               <li class="nav-item">
                 {# URL provided by django-allauth/account/urls.py #}

--- a/trivianator/templates/base.html
+++ b/trivianator/templates/base.html
@@ -53,6 +53,14 @@
             {% if request.user.is_authenticated %}
               <li class="nav-item">
                 {# URL provided by django-allauth/account/urls.py #}
+                <a class="nav-link" href="{% url 'trivia/progress' request.user.username  %}">{% trans "Progress" %}</a>
+              </li>
+              <li class="nav-item">
+                {# URL provided by django-allauth/account/urls.py #}
+                <a class="nav-link" href="{% url 'trivia/leaderboards' request.user.username  %}">{% trans "Leaderboards" %}</a>
+              </li>
+              <li class="nav-item">
+                {# URL provided by django-allauth/account/urls.py #}
                 <a class="nav-link" href="{% url 'users:detail' request.user.username  %}">{% trans "My Profile" %}</a>
               </li>
               <li class="nav-item">

--- a/trivianator/templates/base.html
+++ b/trivianator/templates/base.html
@@ -47,9 +47,6 @@
             <li class="nav-item active">
               <a class="nav-link" href="{% url 'home' %}">Home <span class="sr-only">(current)</span></a>
             </li>
-            <li class="nav-item">
-              <a class="nav-link" href="{% url 'about' %}">About</a>
-            </li>
             {% if request.user.is_authenticated %}
               <li class="nav-item">
                 <a class="nav-link" href="{% url 'progress' %}">{% trans "Progress" %}</a>
@@ -75,6 +72,9 @@
                 <a id="log-in-link" class="nav-link" href="{% url 'account_login' %}">{% trans "Sign In" %}</a>
               </li>
             {% endif %}
+            <li class="nav-item">
+              <a class="nav-link" href="{% url 'about' %}">About</a>
+            </li>
           </ul>
         </div>
       </nav>

--- a/trivianator/templates/pages/about.html
+++ b/trivianator/templates/pages/about.html
@@ -1,1 +1,8 @@
 {% extends "base.html" %}
+
+{% block content %}
+
+    {% load static %}
+	<img src="{% static "images/createdby.png" %}" alt="Author Image">
+
+{% endblock %}

--- a/trivianator/trivia/models.py
+++ b/trivianator/trivia/models.py
@@ -751,7 +751,7 @@ def json_upload_post_save(sender, instance, created, *args, **kwargs):
                     question_type = question['QuestionType'].lower(),
                     category = q_cat[0],
                     content = question['Content'],
-                    explanation = question['Explanation'] if 'Explanation' in question else "",
+                    explanation = question['Explanation'] if 'Explanation' in question else None,
                     answer_order = sanitize_string(question['AnswerOrder']) if 'AnswerOrder' in question and question['AnswerOrder'] != "" else 'none',
                 )
 

--- a/trivianator/trivia/models.py
+++ b/trivianator/trivia/models.py
@@ -168,6 +168,10 @@ class Quiz(models.Model):
         return Leaderboard.objects.filter(quiz=self).order_by('-score', 'completion_time')[:30]
 
     @property
+    def get_leaderboard_count(self):
+        return Leaderboard.objects.filter(quiz=self).count()
+
+    @property
     def end_time_expired(self):
         if self.competitive:
             if now() >= self.end_time:
@@ -514,7 +518,7 @@ class Sitting(models.Model):
         if with_answers:
             user_answers = json.loads(self.user_answers)
             for question in questions:
-                try: 
+                try:
                     question.user_answer = user_answers[str(question.id)]
                 except KeyError:
                     # quiz or question timer expired

--- a/trivianator/trivia/templates/leaderboard_block.html
+++ b/trivianator/trivia/templates/leaderboard_block.html
@@ -1,0 +1,24 @@
+{% load i18n %}
+{% load quiz_tags %}
+
+<div>
+  <h2>{% trans "Leaderboards" %}</h2>
+  <table class="table table-bordered table-striped">
+    <thead>
+      <tr>
+          <th>{% trans "Username" %}</th>
+          <th>{% trans "Score" %}</th>
+          <th>{% trans "Completion Time" %}</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for entry in quiz.get_leaderboard %}
+          <tr>
+              <td>{{ entry.user.username }}</td>
+              <td>{{ entry.score }}</td>
+              <td>{{ entry.completion_time|smooth_timedelta }}</td>
+          </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>

--- a/trivianator/trivia/templates/leaderboard_detail.html
+++ b/trivianator/trivia/templates/leaderboard_detail.html
@@ -1,0 +1,26 @@
+{% load i18n %}
+{% load quiz_tags %}
+
+{% if sitting.complete and quiz.show_leaderboards and quiz.competitive and no_longer_competitive %}
+  <div>
+    <h2>{% trans "Leaderboards" %}</h2>
+    <table class="table table-bordered table-striped">
+      <thead>
+        <tr>
+            <th>{% trans "Username" %}</th>
+            <th>{% trans "Score" %}</th>
+            <th>{% trans "Completion Time" %}</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for entry in quiz.get_leaderboard %}
+            <tr>
+                <td>{{ entry.user.username }}</td>
+                <td>{{ entry.score }}</td>
+                <td>{{ entry.completion_time|smooth_timedelta }}</td>
+            </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+{% endif %}

--- a/trivianator/trivia/templates/leaderboard_detail.html
+++ b/trivianator/trivia/templates/leaderboard_detail.html
@@ -1,26 +1,9 @@
+{% extends 'base.html' %}
 {% load i18n %}
 {% load quiz_tags %}
 
-{% if sitting.complete and quiz.show_leaderboards and quiz.competitive and no_longer_competitive %}
-  <div>
-    <h2>{% trans "Leaderboards" %}</h2>
-    <table class="table table-bordered table-striped">
-      <thead>
-        <tr>
-            <th>{% trans "Username" %}</th>
-            <th>{% trans "Score" %}</th>
-            <th>{% trans "Completion Time" %}</th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for entry in quiz.get_leaderboard %}
-            <tr>
-                <td>{{ entry.user.username }}</td>
-                <td>{{ entry.score }}</td>
-                <td>{{ entry.completion_time|smooth_timedelta }}</td>
-            </tr>
-        {% endfor %}
-      </tbody>
-    </table>
-  </div>
-{% endif %}
+{% block content %}
+  {% with object as quiz %}
+    {% include 'leaderboard_block.html' %}
+  {% endwith %}
+{% endblock %}

--- a/trivianator/trivia/templates/leaderboard_list.html
+++ b/trivianator/trivia/templates/leaderboard_list.html
@@ -19,7 +19,7 @@
       <tbody>
   			{% for quiz in competitive_old %}
   				<tr>
-  				  <td><a href="{% url 'quiz_leaderboards' leaderboard=quiz.url %}">{{ quiz.title }}</a></td>
+  				  <td><a href="{% url 'quiz_leaderboards' slug=quiz.url %}">{{ quiz.title }}</a></td>
             <td>{{ quiz.get_leaderboard_count }}</td>
             <td>{{ quiz.end_time }}</td>
   				</tr>

--- a/trivianator/trivia/templates/leaderboard_list.html
+++ b/trivianator/trivia/templates/leaderboard_list.html
@@ -5,4 +5,27 @@
 
 {% block content %}
 <h1>{% trans "All Leaderboards" %}</h1>
+<p>{{ now }}</p>
+
+  {% if competitive_old %}
+    <table class="table table-bordered table-striped">
+      <thead>
+        <tr>
+          <th>{% trans "Quiz Leaderboards Link" %}</th>
+          <th>{% trans "Num Participants" %}</th>
+          <th>{% trans "DateTime Ended" %}</th>
+        </tr>
+      </thead>
+      <tbody>
+  			{% for quiz in competitive_old %}
+  				<tr>
+  				  <td><a href="{% url 'quiz_leaderboards' leaderboard=quiz.url %}">{{ quiz.title }}</a></td>
+            <td>{{ quiz.get_leaderboard_count }}</td>
+            <td>{{ quiz.end_time }}</td>
+  				</tr>
+  			{% endfor %}
+  		</tbody>
+    </table>
+  {% endif %}
+
 {% endblock %}

--- a/trivianator/trivia/templates/leaderboard_list.html
+++ b/trivianator/trivia/templates/leaderboard_list.html
@@ -12,6 +12,7 @@
       <thead>
         <tr>
           <th>{% trans "Quiz Leaderboards Link" %}</th>
+          <th>{% trans "Quiz Title" %}</th>
           <th>{% trans "Num Participants" %}</th>
           <th>{% trans "DateTime Ended" %}</th>
         </tr>
@@ -19,7 +20,8 @@
       <tbody>
   			{% for quiz in competitive_old %}
   				<tr>
-  				  <td><a href="{% url 'quiz_leaderboards' leaderboard=quiz.pk %}">{{ quiz.title }}</a></td>
+            <td><a href="{% url 'quiz_leaderboards' leaderboard=quiz.pk %}">{% trans "Leaderboard" %}</a></td>
+            <td>{{ quiz.title }}</td>
             <td>{{ quiz.get_leaderboard_count }}</td>
             <td>{{ quiz.end_time }}</td>
   				</tr>

--- a/trivianator/trivia/templates/leaderboard_list.html
+++ b/trivianator/trivia/templates/leaderboard_list.html
@@ -1,0 +1,8 @@
+{% extends 'base.html' %}
+{% load i18n %}
+{% load quiz_tags %}
+{% block title %}{% trans "All Leaderboards" %}{% endblock %}
+
+{% block content %}
+<h1>{% trans "All Leaderboards" %}</h1>
+{% endblock %}

--- a/trivianator/trivia/templates/leaderboard_list.html
+++ b/trivianator/trivia/templates/leaderboard_list.html
@@ -19,7 +19,7 @@
       <tbody>
   			{% for quiz in competitive_old %}
   				<tr>
-  				  <td><a href="{% url 'quiz_leaderboards' slug=quiz.url %}">{{ quiz.title }}</a></td>
+  				  <td><a href="{% url 'quiz_leaderboards' leaderboard=quiz.pk %}">{{ quiz.title }}</a></td>
             <td>{{ quiz.get_leaderboard_count }}</td>
             <td>{{ quiz.end_time }}</td>
   				</tr>

--- a/trivianator/trivia/templates/result.html
+++ b/trivianator/trivia/templates/result.html
@@ -61,7 +61,7 @@
   <hr><p class="lead">{{ sitting.result_message }}</p>
 
   <hr>
-    {% include 'trivia/leaderboard_detail.html' %}
+    {% include 'leaderboard_detail.html' %}
   <hr>
 
   <div>

--- a/trivianator/trivia/templates/result.html
+++ b/trivianator/trivia/templates/result.html
@@ -59,31 +59,9 @@
   {% endif %}
 
   <hr><p class="lead">{{ sitting.result_message }}</p>
-    
+
   <hr>
-  {% if sitting.complete and quiz.show_leaderboards and quiz.competitive and no_longer_competitive %}
-    <div>
-      <h2>{% trans "Leaderboards" %}</h2>
-      <table class="table table-bordered table-striped">
-      <thead>
-        <tr>
-            <th>{% trans "Username" %}</th>
-            <th>{% trans "Score" %}</th>
-            <th>{% trans "Completion Time" %}</th>
-        </tr>
-      </thead>
-      <tbody>
-      {% for entry in quiz.get_leaderboard %}
-          <tr>
-              <td>{{ entry.user.username }}</td>
-              <td>{{ entry.score }}</td>
-              <td>{{ entry.completion_time|smooth_timedelta }}</td>
-          </tr>
-      {% endfor %}
-      </tbody>
-      </table>
-    </div>
-  {% endif %}
+    {% include 'trivia/leaderboard_detail.html' %}
   <hr>
 
   <div>

--- a/trivianator/trivia/templates/result.html
+++ b/trivianator/trivia/templates/result.html
@@ -37,7 +37,7 @@
   {% if previous.previous_question.explanation %}
   <p><strong>{% trans "Explanation" %}:</strong></p>
   <div class="alert alert-debug">
-    <p>{{ previous.previous_question.explanation }}</p>
+    {{ previous.previous_question.explanation }}
   </div>
   <hr>
   {% endif %}
@@ -61,7 +61,9 @@
   <hr><p class="lead">{{ sitting.result_message }}</p>
 
   <hr>
-    {% include 'leaderboard_detail.html' %}
+    {% if sitting.complete and quiz.show_leaderboards and quiz.competitive and no_longer_competitive %}
+      {% include 'leaderboard_block.html' %}
+    {% endif %}
   <hr>
 
   <div>
@@ -99,7 +101,7 @@
 
 	  <p><strong>{% trans "Explanation" %}:</strong></p>
 	  <div class="alert alert-debug">
-		  <p>{{ question.explanation }}</p>
+		  {{ question.explanation }}
 	  </div>
 
 	  <hr>

--- a/trivianator/trivia/templates/trivia/quiz_list.html
+++ b/trivianator/trivia/templates/trivia/quiz_list.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 	<h5>{% trans "Current Server DateTime: " %}{{ now }}</h5>
-	
+
 	{% if competitive %}
 		<h2>{% trans "List of Competitive Quizzes" %}</h2>
 		<table class="table table-bordered table-striped">

--- a/trivianator/trivia/urls.py
+++ b/trivianator/trivia/urls.py
@@ -7,6 +7,14 @@ urlpatterns = [
         view=views.QuizListView.as_view(),
         name='quiz_index'),
 
+    path(route='progress/',
+        view=views.QuizUserProgressView.as_view(),
+        name='quiz_progress'),
+
+    path(route='leaderboards/',
+        view=views.QuizLeaderboardsView.as_view(),
+        name='quiz_leaderboards'),
+
     re_path(route=r'^category/$',
         view=views.CategoriesListView.as_view(),
         name='quiz_category_list_all'),
@@ -14,10 +22,6 @@ urlpatterns = [
     re_path(route=r'^category/(?P<category_name>[\w|\W-]+)/$',
         view=views.ViewQuizListByCategory.as_view(),
         name='quiz_category_list_matching'),
-
-    re_path(route=r'^progress/$',
-        view=views.QuizUserProgressView.as_view(),
-        name='quiz_progress'),
 
     re_path(route=r'^marking/$',
         view=views.QuizMarkingList.as_view(),

--- a/trivianator/trivia/urls.py
+++ b/trivianator/trivia/urls.py
@@ -42,7 +42,7 @@ urlpatterns = [
         name='quiz_question'),
 
     #  passes variable 'leaderboard' to leaderboard detail view
-    re_path(route=r'leaderboards/(?P<slug>[\w-]+)/$',
-        view=views.QuizLeaderboardsDetailView.as_view(),
+    re_path(route=r'leaderboards/(?P<leaderboard>\d+)/$',
+        view=views.QuizLeaderboardsDetailView.as_view(pk_url_kwarg='leaderboard'),
         name='quiz_leaderboards'),
 ]

--- a/trivianator/trivia/urls.py
+++ b/trivianator/trivia/urls.py
@@ -9,7 +9,7 @@ urlpatterns = [
 
     path(route='progress/',
         view=views.QuizUserProgressView.as_view(),
-        name='quiz_progress'),
+        name='progress'),
 
     path(route='leaderboards/',
         view=views.QuizLeaderboardsView.as_view(),
@@ -41,8 +41,8 @@ urlpatterns = [
         view=views.QuizTake.as_view(),
         name='quiz_question'),
 
-    #  passes variable 'slug' to leaderboard detail view
-    re_path(route=r'^(?P<leaderboard>[\w-]+)/$',
+    #  passes variable 'leaderboard' to leaderboard detail view
+    re_path(route=r'leaderboards/(?P<slug>[\w-]+)/$',
         view=views.QuizLeaderboardsDetailView.as_view(),
         name='quiz_leaderboards'),
 ]

--- a/trivianator/trivia/urls.py
+++ b/trivianator/trivia/urls.py
@@ -13,7 +13,7 @@ urlpatterns = [
 
     path(route='leaderboards/',
         view=views.QuizLeaderboardsView.as_view(),
-        name='quiz_leaderboards'),
+        name='leaderboards'),
 
     re_path(route=r'^category/$',
         view=views.CategoriesListView.as_view(),
@@ -40,4 +40,9 @@ urlpatterns = [
     re_path(route=r'^(?P<quiz_name>[\w-]+)/take/$',
         view=views.QuizTake.as_view(),
         name='quiz_question'),
+
+    #  passes variable 'slug' to leaderboard detail view
+    re_path(route=r'^(?P<leaderboard>[\w-]+)/$',
+        view=views.QuizLeaderboardsDetailView.as_view(),
+        name='quiz_leaderboards'),
 ]

--- a/trivianator/trivia/views.py
+++ b/trivianator/trivia/views.py
@@ -156,12 +156,20 @@ class QuizLeaderboardsView(QuizListView):
 
 class QuizLeaderboardsDetailView(DetailView):
     model = Quiz
-    leaderboard_field = 'url'
+    template_name = 'leaderboard_detail.html'
+    slug_field = 'url'
 
-    def get(self, request, *args, **kwargs):
-        self.object = self.get_object()
-        context = self.get_context_data(object=self.object)
-        return self.render_to_response(context)
+    def get_queryset(self):
+        queryset = super(QuizLeaderboardsDetailView, self).get_queryset()
+        return queryset.filter(draft=False)
+
+    def get_context_data(self, **kwargs):
+        context = super(QuizLeaderboardsDetailView, self).get_context_data(**kwargs)
+
+    #def get(self, request, *args, **kwargs):
+    #    self.object = self.get_object()
+    #    context = self.get_context_data(object=self.object)
+    #    return self.render_to_response(context)
 
 
 class QuizMarkingList(QuizMarkerMixin, SittingFilterTitleMixin, ListView):

--- a/trivianator/trivia/views.py
+++ b/trivianator/trivia/views.py
@@ -150,9 +150,18 @@ class QuizLeaderboardsView(QuizListView):
             if q.end_time <= now():
                 context['competitive_old'].append(q)
 
-        context['competitive_upcoming_count'] = len(context['competitive_upcoming'])
         context['competitive_old_count'] = len(context['competitive_old'])
         return context
+
+
+class QuizLeaderboardsDetailView(DetailView):
+    model = Quiz
+    leaderboard_field = 'url'
+
+    def get(self, request, *args, **kwargs):
+        self.object = self.get_object()
+        context = self.get_context_data(object=self.object)
+        return self.render_to_response(context)
 
 
 class QuizMarkingList(QuizMarkerMixin, SittingFilterTitleMixin, ListView):

--- a/trivianator/trivia/views.py
+++ b/trivianator/trivia/views.py
@@ -53,7 +53,7 @@ class QuizListView(ListView):
                 context['competitive_upcoming'].append(q)
             elif q.end_time <= now():
                 context['competitive_old'].append(q)
-        
+
         context['generic_new'] = []
         context['generic_taken'] = []
         context['generic_results'] = {}
@@ -130,6 +130,28 @@ class QuizUserProgressView(TemplateView):
                 context['display_categories'] = False
                 context['hide'].append(quiz.quiz.title)
                 break
+        return context
+
+
+class QuizLeaderboardsView(QuizListView):
+    template_name = 'leaderboard_list.html'
+    model = Quiz
+    # @login_required
+    def get_queryset(self):
+        queryset = super(QuizLeaderboardsView, self).get_queryset()
+        return queryset.filter(draft=False)
+
+    def get_context_data(self, **kwargs):
+        context = super(QuizLeaderboardsView, self).get_context_data(**kwargs)
+        q_competitive = self.get_queryset().filter(competitive=True)
+        context['now'] = now()
+        context['competitive_old'] = []
+        for q in q_competitive:
+            if q.end_time <= now():
+                context['competitive_old'].append(q)
+
+        context['competitive_upcoming_count'] = len(context['competitive_upcoming'])
+        context['competitive_old_count'] = len(context['competitive_old'])
         return context
 
 

--- a/trivianator/trivia/views.py
+++ b/trivianator/trivia/views.py
@@ -154,22 +154,9 @@ class QuizLeaderboardsView(QuizListView):
         return context
 
 
-class QuizLeaderboardsDetailView(DetailView):
+class QuizLeaderboardsDetailView(SittingFilterTitleMixin, DetailView):
     model = Quiz
     template_name = 'leaderboard_detail.html'
-    slug_field = 'url'
-
-    def get_queryset(self):
-        queryset = super(QuizLeaderboardsDetailView, self).get_queryset()
-        return queryset.filter(draft=False)
-
-    def get_context_data(self, **kwargs):
-        context = super(QuizLeaderboardsDetailView, self).get_context_data(**kwargs)
-
-    #def get(self, request, *args, **kwargs):
-    #    self.object = self.get_object()
-    #    context = self.get_context_data(object=self.object)
-    #    return self.render_to_response(context)
 
 
 class QuizMarkingList(QuizMarkerMixin, SittingFilterTitleMixin, ListView):


### PR DESCRIPTION
Closes #22 

Creates NavBar URL Links for "Progress" and "Leaderboards" for authenticated users.

Broke-out leaderboard associated table into /templates/trivia/leaderboard_detail.html which is now included by result.html
Created /templates/trivia/leaderboard_list.html to list all Leaderboards as the landing page of "Leaderboards" NavBar link.